### PR TITLE
Updating Versions (Python, Github Actions and flake/black)

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/lint-and-test.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/lint-and-test.yml
@@ -6,13 +6,13 @@ on: push
 jobs:
   check:
     runs-on: ubuntu-latest
-    name: "Check (on Python3.8)"
+    name: "Check (on Python3.9)"
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
-      - uses: actions/checkout@v2
-      - uses: pre-commit/action@v2.0.0
+          python-version: 3.9
+      - uses: actions/checkout@v3
+      - uses: pre-commit/action@v3.0.0
 
   test:
     needs: check
@@ -21,11 +21,11 @@ jobs:
       fail-fast: false
     name: "Test (on Python 3.9)"
     steps:
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.9
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get history and tags for SCM versioning to work
         run: |
           git fetch --prune --unshallow

--- a/{{cookiecutter.plugin_name}}/requirements/dev.in
+++ b/{{cookiecutter.plugin_name}}/requirements/dev.in
@@ -2,8 +2,9 @@
 -c test.txt
 
 pre-commit
-black
-flake8
+# we're pinning the following two to what .pre-commit-config.yaml says
+black==22.3.0
+flake8==4.0.1
 flake8-blind-except
 mypy
 pytest-runner


### PR DESCRIPTION
Updating Github Actions versions, Python versions (3.8 -> 3.9) and pinning flake8 and black versions (Similar to what is done in the project [FlexMeasures/flexmeasures](https://github.com/FlexMeasures/flexmeasures) following pre-commit recommendations.