### PR TITLE
update auth handling in API test

### DIFF
--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/somedata.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/somedata.py
@@ -1,11 +1,11 @@
-from flask_security import login_required
+from flask_security import auth_token_required
 from flask_json import as_json
 
 from .. import {{cookiecutter.module_name}}_api_bp
 
 
 @{{cookiecutter.module_name}}_api_bp.route("/somedata")
-@login_required
+@auth_token_required
 @as_json
 def somedata():
     return dict(a=1, b=2)

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
@@ -1,11 +1,16 @@
 from flask import url_for
 
 
-def test_get_somedata_needs_login(client):
-    response = client.get(url_for("{{cookiecutter.plugin_name}} API.somedata"), follow_redirects=True)
-    # TODO: this test requires authentication. Future work:
-    # a) FM gives back HTML now, but after https://github.com/FlexMeasures/flexmeasures/pull/210 it should be JSON
-    # b) we should add a user, which also requires us to add a db to testing
-    assert response.status_code == 200  # should be 401
-    assert "text/html" in response.content_type  # response should be JSON
-    assert b"Please log in" in response.data
+def test_get_somedata_needs_authtoken(client):
+    response = client.get(
+        url_for("{{cookiecutter.plugin_name}} API.somedata"),
+        headers={"content-type": "application/json"},
+        follow_redirects=True
+    )
+    assert response.status_code == 401  # should be 401
+    assert "application/json" in response.content_type  # response should be JSON
+    assert "not be properly authenticated" in response.json["message"]
+
+    
+# TODO: The somedata endpoint requires authentication to be testes successfully.
+#       We'll need to add a user in conftest, which also requires us to add a db to testing

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
@@ -7,8 +7,8 @@ def test_get_somedata_needs_authtoken(client):
         headers={"content-type": "application/json"},
         follow_redirects=True
     )
-    assert response.status_code == 401  # should be 401
-    assert "application/json" in response.content_type  # response should be JSON
+    assert response.status_code == 401  # HTTP error code 401 Unauthorized.
+    assert "application/json" in response.content_type
     assert "not be properly authenticated" in response.json["message"]
 
     


### PR DESCRIPTION
Closes #17. We were using an unfitting auth decorator for the dummy API here.