### PR TITLE
Dockerfile to deploy plugin

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
   "author_name": "",
   "author_email": "",
   "plugin_url": "",
-  "minimal_flexmeasures_version": "0.12.0",
+  "minimal_flexmeasures_version": "0.14.0",
   "api_blueprint": "y",
   "ui_blueprint": "y",
   "cli_blueprint": "y"

--- a/{{cookiecutter.plugin_name}}/Dockerfile
+++ b/{{cookiecutter.plugin_name}}/Dockerfile
@@ -4,6 +4,6 @@ FROM lfenergy/flexmeasures
 #COPY requirements/app.in /app/requirements/{{cookiecutter.module_name}}.txt
 #RUN pip3 install --no-cache-dir -r requirements/{{cookiecutter.module_name}}.txt
 
-# Make sure FlexMeasures recognizes this plugin (requires FlexMeasures v0.14)
 COPY {{cookiecutter.module_name}}/ /app/{{cookiecutter.module_name}}
+# Make sure FlexMeasures recognizes this plugin (requires FlexMeasures v0.14)
 ENV FLEXMEASURES_PLUGINS="/app/{{cookiecutter.module_name}}"

--- a/{{cookiecutter.plugin_name}}/Dockerfile
+++ b/{{cookiecutter.plugin_name}}/Dockerfile
@@ -1,0 +1,9 @@
+FROM lfenergy/flexmeasures
+
+# Install requirements, e.g. like this
+#COPY requirements/app.in /app/requirements/{{cookiecutter.module_name}}.txt
+#RUN pip3 install --no-cache-dir -r requirements/{{cookiecutter.module_name}}.txt
+
+# Make sure FlexMeasures recognizes this plugin (requires FlexMeasures v0.14)
+COPY {{cookiecutter.module_name}}/ /app/{{cookiecutter.module_name}}
+ENV FLEXMEASURES_PLUGINS="/app/{{cookiecutter.module_name}}"


### PR DESCRIPTION
This PR proposes a short Dockerfile based on lfenergy/flexmeasures, which would contain the plugin's extra logic and even requirements.

I tested this with the plugin template in FlexMeasures' docker compose stack, and I could see that the `http://localhost:5000/flexmeasures_testplugin/api/somedata` endpoint, worked as well as the `hello-world` CLI command inside the container. 